### PR TITLE
#4 source/local data mismatch

### DIFF
--- a/mediamultitool/config.py
+++ b/mediamultitool/config.py
@@ -30,6 +30,7 @@ class PlaylistConfig:
     blocklist_strings: str = ''
     allowlist_strings: str = ''
     default_output: str = ''
+    artist_aliases: dict[str, str] = field(default_factory=dict)
 
 @dataclass(slots=True)
 class CleanerConfig:
@@ -37,7 +38,7 @@ class CleanerConfig:
 
 @dataclass(slots=True)
 class Misc:
-    version: str = '0.1.2'
+    version: str = '0.1.3'
 
 @dataclass(slots=True)
 class AppConfig:

--- a/mediamultitool/config.toml
+++ b/mediamultitool/config.toml
@@ -24,11 +24,17 @@ allowlist_strings = ''
 # default output directory for m3u8 files
 default_output = ''
 
+# below is where you should define alternative names for artists you find while using mmt
+# in the case where the artist "30 Seconds To Mars" is stored locally but in the playlist
+# data, it's defined as "Thirty Seconds To Mars" (you do not need to include the inverse order of names)
+[app.playlist.artist_aliases]
+"30 Seconds To Mars" = "Thirty Seconds To Mars"
+
 [app.cleaner]
 # location of where you download/rip your albums to
 download_path = ''
 
 [app.misc]
 # versioning DO NOT CHANGE
-version = '0.1.2'
+version = '0.1.3'
 

--- a/mediamultitool/mmt/main.py
+++ b/mediamultitool/mmt/main.py
@@ -33,7 +33,8 @@ def run(args, cfg):
             output_path = output_dir,
             lastfm_api_key = cfg.apis.lastfm_api_key,
             blocklist_strs = cfg.playlist.blocklist_strings.split(","),
-            allowlist_strs = cfg.playlist.allowlist_strings.split(",")
+            allowlist_strs = cfg.playlist.allowlist_strings.split(","),
+            artist_aliases = cfg.playlist.artist_aliases
         )
 
         input_param = [x for x in input_params if x.startswith("http")]
@@ -58,7 +59,7 @@ def run(args, cfg):
 
             else:
                 for i in input_params: # args.input_param now gives a list so iterate through
-                    csv_file_path = Path(input) 
+                    csv_file_path = Path(i) 
                     convert_csv(csv_file_path, playlist_cfg)
 
     if args.command == "cleaner":

--- a/mediamultitool/mmt/models.py
+++ b/mediamultitool/mmt/models.py
@@ -15,6 +15,7 @@ class PlaylistConfig:
     lastfm_api_key: str | None # nullable because a user may not want to convert last.fm playlists
     blocklist_strs: list[str] = field(default_factory=list) # default to an empty list
     allowlist_strs: list[str] = field(default_factory=list)
+    artist_aliases: dict[str, str] = field(default_factory=dict)
 
 """
     Sources/credit:

--- a/mediamultitool/mmt/playlist/search.py
+++ b/mediamultitool/mmt/playlist/search.py
@@ -63,6 +63,18 @@ def search_music(tracks, pl_cfg: object, playlist_name):
 
         if "&" in raw_artist: # solves the case "&" in "macklemore & ryan lewis"
             raw_artist = raw_artist.split("&", 1)[0].strip()
+        if "-" in raw_artist:
+            raw_artist = raw_artist.replace("-", "") # was previously performing this normalisation in the artist matching section which meant it
+            # would not be performed, will look at moving these into a special rule (this time probably not definable by users)
+
+        artist_names = {raw_artist} # convert raw artist to a set
+
+        for key, value in pl_cfg.artist_aliases.items(): # solves the case: "30 Seconds to mars" locally, "Thirty Seconds To Mars" in playlist data
+            n_key = normalise(key)
+            n_value = normalise(value)
+
+            if raw_artist in {n_key, n_value}: # iterate through the the dictionary
+                artist_names.update({n_key, n_value}) # and normalise the provided values and add that to the artist_names set
 
         raw_album = raw_album.split("(")[0].strip() # solves the case: "Spawn The Album (Soundtrack)"
 
@@ -84,11 +96,11 @@ def search_music(tracks, pl_cfg: object, playlist_name):
 
             if "-" in folder_artist: # the ceelo green rule
                 folder_artist = folder_artist.replace("-", "")
-                raw_artist = raw_artist.replace("-", "")
 
-            if folder_artist == raw_artist:
-                artist_path = artist
-                break
+            for artist_name in artist_names:
+                if folder_artist == artist_name:
+                    artist_path = artist
+                    break
         
         if artist_path == None:
             missing_tracks += 1
@@ -156,3 +168,11 @@ def search_music(tracks, pl_cfg: object, playlist_name):
     container_paths = get_container_path(full_path_list, music_path, pl_cfg)
 
     create_m3u8(container_paths, pl_cfg, playlist_name)
+
+"""
+    Sources/credit:
+        - artist_aliases dict:  https://www.w3schools.com/python/python_dictionaries_add.asp
+                                https://stackoverflow.com/questions/38987/how-do-i-merge-two-dictionaries-in-a-single-expression-in-python
+                                https://stackoverflow.com/questions/483666/reverse-invert-a-dictionary-mapping
+            - i didn't uses the bottom two as that was the inital approach and didn't yet know the power of sets
+"""


### PR DESCRIPTION
Adds a fix for mismatched local/source data.

- Identified that Spotify mislabels "30 Seconds To Mars" as "Thirty Seconds To Mars" which causes their tracks to not be found
- Added a user customisable config toml table to input their own mismatches
- Decided against the approach of using multiple keys for the same potential mismatch as discussed in [#4](https://github.com/naomisilver/mediamultitool/issues/4)

Closes #4 