### PR TITLE
20 updater download missing

### DIFF
--- a/mediamultitool/config.py
+++ b/mediamultitool/config.py
@@ -45,10 +45,12 @@ class UpdaterConfig:
     ignore_live_albums: bool = False
     check_new_or_all: str = ''
     excluded: str = ''
+    deezer_arl_token: str = ''
+    download_source: str = 'deezer'
 
 @dataclass(slots=True)
 class Misc:
-    version: str = '0.1.4'
+    version: str = '0.1.5'
 
 @dataclass(slots=True)
 class AppConfig:

--- a/mediamultitool/config.toml
+++ b/mediamultitool/config.toml
@@ -59,6 +59,14 @@ check_new_or_all = ''
 # or "Artist Collection". Seperate entries here using a command (,)
 excluded = 'Various Artists, Playlists'
 
+# required when downloading music from deezer, to get your token, follow this guide:
+# https://github.com/nathom/streamrip/wiki/Finding-Your-Deezer-ARL-Cookie
+deezer_arl_token = ''
+
+# this determines which source to download music from. Currently only Deezer is supported with plans to support Qobuz
+# in the future.
+download_source = 'deezer'
+
 [app.misc]
 # versioning DO NOT CHANGE
-version = '0.1.4'
+version = '0.1.5'

--- a/mediamultitool/mmt/cli.py
+++ b/mediamultitool/mmt/cli.py
@@ -169,6 +169,7 @@ def mmt():
     updater_parser.add_argument("-e", "--excluding", dest="excluding", nargs="+", type=str, help="scan for albums excluding the given artist(s)")
     updater_parser.add_argument("-p", "--print", dest="print_console", action="store_true",help="Outputs missing albums to the console rather than file")
     updater_parser.add_argument("-r", "--refresh-artist", dest="refresh", nargs=1, type=str, help="refresh a bad artist match")
+    updater_parser.add_argument("-d", "--download", action="store_true", help="download the found missing albums")
     updater_parser.set_defaults(command="updater")
     
     args = parser.parse_args()

--- a/mediamultitool/mmt/core/models.py
+++ b/mediamultitool/mmt/core/models.py
@@ -27,7 +27,7 @@ class PlaylistConfig:
     local_music_path: Path
     container_root: Path
     output_path: Path
-    lastfm_api_key: str | None # nullable because a user may not want to convert last.fm playlists
+    lastfm_api_key: str = None # nullable because a user may not want to convert last.fm playlists
     blocklist_strs: list[str] = field(default_factory=list) # default to an empty list
     allowlist_strs: list[str] = field(default_factory=list)
     artist_aliases: dict[str, str] = field(default_factory=dict)
@@ -38,7 +38,10 @@ class UpdaterConfig: # small now but will make things easier if I do move to aut
     output_dir: Path
     db_path: Path
     update_cache: bool
+    download_source: str
+    download: bool
     all_or_new: bool
+    deezer_arl_token: str = None
     output_to_console: bool = False
     ignore: dict[str, bool] = field(default_factory=dict) # store the ignores in a dictionary so I can iterate over it, no more big if block
     excluded_artists: list = field(default_factory=list) 

--- a/mediamultitool/mmt/core/normalise.py
+++ b/mediamultitool/mmt/core/normalise.py
@@ -1,10 +1,12 @@
-def normalise(s):
+import re
+
+def normalise(s): # will need a name change in the future, but changing this now means editing half a dozen files and not required rn
     """ small helper to strip down to the absolute bare required data for string/partial string matching """
     if s is None:
         s = "none" # for the instances of a user misinputting their API key and last.fm returns a bunch of nulls or last.fm api can't find an album for a specific track
 
     s = s.lower().strip()
-    illegal = '<>:"/\\|?*\''
+    illegal = '<>:"/!\\|?*\'~'
     s = "".join(c for c in s if c not in illegal) # solves the general case of illegal os characters (breaks AC/DC but is solved by discrete artist search)
     s = s.rstrip(".") # solves the case of hkmori's "i just want to be your friend..."
     s = s.replace("’", "'").replace("‘", "'").replace("“", '"').replace("”", '"') # "holy grail’" vs "holy grail'" this is to catch for musicbrainz entries

--- a/mediamultitool/mmt/core/richui.py
+++ b/mediamultitool/mmt/core/richui.py
@@ -14,6 +14,7 @@ class RichUI:
         self.missing_tracks = []
         self.matching_tracks = []
         self.missing_albums = []
+        self.matching_ids = []
         self.current_artist_name = None
 
         self.con = Console()
@@ -78,6 +79,9 @@ class RichUI:
 
         if self.missing_albums:
             renderables.append(self._make_missing_albums_table())
+
+        if self.matching_ids:
+            renderables.append(self._make_matched_album_ids_table())
 
         return Group(*renderables)
 
@@ -167,6 +171,25 @@ class RichUI:
             table.add_row(*r)
 
         return table
+    
+    def _make_matched_album_ids_table(self):
+        """ table creation for matched album ids for mmt updater -d/--download """
+
+        table = self._new_table(title="Matched IDs", title_style = self.info_style)
+        table.add_column("Artist", width=28, style=self.warning_style, header_style=self.info_style, no_wrap=True)
+        table.add_column("ID(s)", width=18, style=self.warning_style, header_style=self.info_style, no_wrap=True)
+        table.add_column("Album Title", width=48, style=self.warning_style, header_style=self.info_style, no_wrap=True)
+
+        for r in self.matching_ids:
+            table.add_row(*r)
+
+        return table
+
+    def matched_album_ids(self, artist_name: str, album: dict, title: str):
+
+        self.matching_ids.append((artist_name, str(album["album_id"]), title))
+        self.matching_ids = self.matching_ids[-5:]
+        self.refresh()
 
     def artist_albums_updated(self, a: CachedArtist, count: int):
         """ row logic for updating the local cache for mmt updater -u/--update-cache limited to 5 most recent gets """

--- a/mediamultitool/mmt/main.py
+++ b/mediamultitool/mmt/main.py
@@ -91,6 +91,9 @@ def run(args, cfg):
             output_dir = Path(cfg.core.default_output) if cfg.core.default_output else DEFAULT_OUTPUT_DIR,
             db_path = DB_PATH,
             update_cache = args.update_cache,
+            deezer_arl_token = cfg.updater.deezer_arl_token,
+            download_source = cfg.updater.download_source.lower(),
+            download = args.download,
             # all_or_new = True if cfg.updater.check_new_or_all.lower() == "all" else False, # had it inverse but I'd prefer it defaults to new if it isn't explcitly "all"
             all_or_new = all_or_new,
             output_to_console = args.print_console,

--- a/mediamultitool/mmt/updater/download_albums.py
+++ b/mediamultitool/mmt/updater/download_albums.py
@@ -1,12 +1,15 @@
 from ..core.models import UpdaterConfig
 from ..core.normalise import normalise
-
+from .streamrip_client import StreamripClient
 from .get_album_id import get_deezer_artist_id, get_deezer_album_id, get_fuzzy_deezer_album_id, get_album_name_from_id
+from streamrip.progress import clear_progress
+from streamrip.media import remove_artwork_tempdirs
 
 from rich import print # so helpful when looking at printed dicts and lists oh my
 import re
 import logging
 from pathlib import Path
+import asyncio
 
 """
     - I'm beholden to what deezer provides and contains and so so there's some noise, some error and weird edge cases like +44/plus 44
@@ -62,6 +65,20 @@ def get_source(upd_cfg: UpdaterConfig, missing_albums: dict[str, dict[str, list[
             print(f"{id}: {get_album_name_from_id(id)}") # im lazy and having a quick way to confirm what gets found is awesome
 
         print(len(to_download))
+
+        asyncio.run(run_downloads(upd_cfg, to_download))
+
+async def run_downloads(upd_cfg: UpdaterConfig, to_download):
+    sr_client = StreamripClient(upd_cfg)
+    await sr_client.init_client()
+
+    try:
+        for id in to_download:
+            await sr_client.deezer_rip(id)
+    finally:
+        await sr_client.close()
+        clear_progress()
+        remove_artwork_tempdirs()
 
 def get_deezer_ids(upd_cfg: UpdaterConfig, missing_albums: dict[str, dict[str, list[str]]]) -> list[int]:
     """ builds list of missing album ids """

--- a/mediamultitool/mmt/updater/download_albums.py
+++ b/mediamultitool/mmt/updater/download_albums.py
@@ -1,0 +1,167 @@
+from ..core.models import UpdaterConfig
+from ..core.normalise import normalise
+
+from .get_album_id import get_deezer_artist_id, get_deezer_album_id, get_fuzzy_deezer_album_id, get_album_name_from_id
+
+from rich import print # so helpful when looking at printed dicts and lists oh my
+import re
+import logging
+from pathlib import Path
+
+"""
+    - I'm beholden to what deezer provides and contains and so so there's some noise, some error and weird edge cases like +44/plus 44
+      out of my small test music (60gb ish of the stuff) with 22 artists, with 18 missing studio albums, i find 15. 
+
+      Jay-z's "the black album revisited", black sabbath's "studio outtakes" and 50 cent's "street king immortal" don't exist on deezer nor qobuz but do on musicbrains
+      so I can't find album ids for them on the two major music downloaders. There will always just be *there*, I could add a "not on deezer"/"not on qobuz"
+      column to the albums table and db querying so that I'm not attempting to find ids for albums which don't exist on the streaming services but then that's
+      more overhead for very little cost. querying deezer is pretty cheap and adding an entire other attribute to the database for a minority occurances seems more
+      expensive than I'm willing. Though if this becomes a guarenteed 1/4 chance then i'll look into it
+"""
+
+logger = logging.getLogger(__name__)
+
+DEEZER_ARTIST_ALIASES = {
+    "+44": "plus 44" # YIPPEE TIME TO ASK THE USER FOR INFORMATION EXCEPT THIS TIME THE USER HAS NO CLUE WHAT TO ALIAS IT WITH YIPPEEEE THANKS BAD DATA
+}
+
+def strip_year(s: str) -> tuple: # will be moved into normalise.py, can't use normalise_album in its current form as it breaks matches like:
+    """ removes the year from a given local title """
+
+    return re.sub(r'\([1-2][0-9][0-9][0-9]\)', "", s).strip() # "hip-hop showdown - 50 cent v snoop dogg (2019)"
+
+# both the surrounding functions need to be moved into normalise.py and reduce the repetetive normalisation I do spread across multitple functions
+# it's only this way right now because I'm dealing with so much data from so many sources and the same normalisation steps done to local files for example
+# would completely wreck my shit when performing the same steps to deezer data 
+
+def further_normalisation(s: str) -> str:
+    """ removes any characters within parenthesis and the parenthesis """
+
+    return re.sub(r"\s*\([^)]*\)\s*$", "", s).strip()
+
+#def resolve_local_artist_dir(base_path: Path, artist: str) -> Path | None:
+#    """ ensures the artist path exists locally, used to ensure artist from deezer matches artist locally """
+
+#    target = normalise(artist)
+
+#    for p in base_path.iterdir():
+#        if not p.is_dir():
+#            continue
+#        if normalise(p.name) == target:
+#            return p
+#
+#    return None # unused since adding fuzzy album query may still be useful in the future for qobuz querying
+
+def get_source(upd_cfg: UpdaterConfig, missing_albums: dict[str, dict[str, list[str]]]):
+    """ determines which download source to use """
+
+    if upd_cfg.download_source.lower() == "deezer":
+        to_download = get_deezer_ids(upd_cfg, missing_albums)
+
+        for id in to_download:
+            print(f"{id}: {get_album_name_from_id(id)}") # im lazy and having a quick way to confirm what gets found is awesome
+
+        print(len(to_download))
+
+def get_deezer_ids(upd_cfg: UpdaterConfig, missing_albums: dict[str, dict[str, list[str]]]) -> list[int]:
+    """ builds list of missing album ids """
+
+    to_download = []
+
+    for artist, album_type in missing_albums.items():
+        for a_type, m_albums in album_type.items():
+
+            singles = True if a_type == "singles" else False
+            allowed_types = {"single"} if singles else {"album", "albums"}
+
+            missing_titles = [further_normalisation(normalise(strip_year(title))) for title in m_albums] # this mess is why i need a standardised normalise.py
+
+            i = 0
+
+            while True: # loops 5 times if the first 4 artists don't have any of what we're looking for, this is where resolve_local_artist_dir was used 
+                        # as I could use the local collection to confirm if the artist was right but i just fuzzy search the albums anyway
+
+                if i == 5:
+                    break
+
+                for k, v in DEEZER_ARTIST_ALIASES.items():
+                    if artist in k: # same reverse matching method used in playlist module
+                        search_artist = v # just not bi directional as the key is known bad
+                    else:
+                        search_artist = artist
+
+                artist_id = get_deezer_artist_id(search_artist, i)
+
+                if not artist_id:
+                    logger.error("No artist id found for artist: %s", artist)
+                    break
+
+                albums = get_deezer_album_id(artist_id, index=0)
+
+                remove_duplicates = {}
+                found_titles = []
+
+                for title, data in albums.items(): # deezer returns multiple albums of the same name but different id as they distinguish between explcit and non-explicit albums I
+                    norm_title = further_normalisation(normalise(title)) # currently have it hard coded to prefer explicit albums shouldn't be too difficult to make it user definable
+
+                    if data["record_type"] not in allowed_types:
+                        continue # remove instances of singles of the same name as a studio album
+
+                    if norm_title not in missing_titles:
+                        continue
+
+                    found_titles.append(norm_title)
+
+                    if norm_title not in remove_duplicates:
+                        remove_duplicates[norm_title] = data
+                        continue
+
+                    if not remove_duplicates[norm_title]["explicit_lyrics"] and data["explicit_lyrics"]: 
+                        remove_duplicates[norm_title] = data
+
+                # ids found from artist album listing
+                matched_ids = [data["album_id"] for data in remove_duplicates.values()]
+
+                print(matched_ids) # will be replaced with rich live table when i come to adding ui elements
+
+                to_download.extend(matched_ids)
+
+                still_missing = [t for t in missing_titles if t not in found_titles]
+
+                for miss in still_missing: # fuzzy search for any albums that remain illusive (~mAntras~ and hell aint a bad place to be (in memory of bon scott))
+
+                    fuzzy_results = get_fuzzy_deezer_album_id(miss, artist)
+
+                    if not fuzzy_results:
+                        continue
+
+                    for res in fuzzy_results:
+                        res_title = further_normalisation(normalise(res["title"]))
+
+                        if miss not in res_title:
+                            continue # sub string match missing name to deezer result, exact matching misses "the forever sessions (vol. 1)", I can comfortably rely on 
+                            # the album name passed in from load_album.py as it's been through 7 levels of normalisation, the same place im going for making this tool :P
+
+                        if res["record_type"] not in allowed_types:
+                            continue # skip if its a single
+
+                        if "artist_name" in res: # if everything else matches but its from a different artist, discard
+                            if normalise(res["artist_name"]) != normalise(artist):
+                                continue
+
+                        to_download.append(res["id"])
+                        break
+
+                if matched_ids or still_missing:
+                    #print(still_missing)
+                    break
+
+                i += 1
+                logger.error("Bad match on artist: %s, trying again", artist)
+
+    return to_download
+                
+"""
+list comp with dictionary: https://stackoverflow.com/questions/27742537/list-comprehensions-extracting-values-from-a-dictionary-in-a-dictionary
+    struggled on a clean way to handle it for a little
+"""

--- a/mediamultitool/mmt/updater/download_albums.py
+++ b/mediamultitool/mmt/updater/download_albums.py
@@ -4,8 +4,9 @@ from .streamrip_client import StreamripClient
 from .get_album_id import get_deezer_artist_id, get_deezer_album_id, get_fuzzy_deezer_album_id, get_album_name_from_id
 from streamrip.progress import clear_progress
 from streamrip.media import remove_artwork_tempdirs
+from ..core.richui import RichUI
 
-from rich import print # so helpful when looking at printed dicts and lists oh my
+#from rich import print # so helpful when looking at printed dicts and lists oh my
 import re
 import logging
 from pathlib import Path
@@ -58,15 +59,15 @@ def further_normalisation(s: str) -> str:
 def get_source(upd_cfg: UpdaterConfig, missing_albums: dict[str, dict[str, list[str]]]):
     """ determines which download source to use """
 
+    ui = RichUI()
+    ui.start()
+
     if upd_cfg.download_source.lower() == "deezer":
-        to_download = get_deezer_ids(upd_cfg, missing_albums)
+        to_download = get_deezer_ids(upd_cfg, ui, missing_albums)
 
-        for id in to_download:
-            print(f"{id}: {get_album_name_from_id(id)}") # im lazy and having a quick way to confirm what gets found is awesome
+    ui.stop()
 
-        print(len(to_download))
-
-        asyncio.run(run_downloads(upd_cfg, to_download))
+    asyncio.run(run_downloads(upd_cfg, to_download))
 
 async def run_downloads(upd_cfg: UpdaterConfig, to_download):
     sr_client = StreamripClient(upd_cfg)
@@ -80,7 +81,7 @@ async def run_downloads(upd_cfg: UpdaterConfig, to_download):
         clear_progress()
         remove_artwork_tempdirs()
 
-def get_deezer_ids(upd_cfg: UpdaterConfig, missing_albums: dict[str, dict[str, list[str]]]) -> list[int]:
+def get_deezer_ids(upd_cfg: UpdaterConfig, ui: RichUI,  missing_albums: dict[str, dict[str, list[str]]]) -> list[int]:
     """ builds list of missing album ids """
 
     to_download = []
@@ -131,6 +132,9 @@ def get_deezer_ids(upd_cfg: UpdaterConfig, missing_albums: dict[str, dict[str, l
 
                     if norm_title not in remove_duplicates:
                         remove_duplicates[norm_title] = data
+
+                        ui.matched_album_ids(artist, data, title)
+
                         continue
 
                     if not remove_duplicates[norm_title]["explicit_lyrics"] and data["explicit_lyrics"]: 
@@ -139,7 +143,7 @@ def get_deezer_ids(upd_cfg: UpdaterConfig, missing_albums: dict[str, dict[str, l
                 # ids found from artist album listing
                 matched_ids = [data["album_id"] for data in remove_duplicates.values()]
 
-                print(matched_ids) # will be replaced with rich live table when i come to adding ui elements
+                #print(matched_ids) # will be replaced with rich live table when i come to adding ui elements
 
                 to_download.extend(matched_ids)
 
@@ -166,7 +170,10 @@ def get_deezer_ids(upd_cfg: UpdaterConfig, missing_albums: dict[str, dict[str, l
                             if normalise(res["artist_name"]) != normalise(artist):
                                 continue
 
-                        to_download.append(res["id"])
+                        to_download.append(res["album_id"])
+
+                        ui.matched_album_ids(artist, res, res_title)
+
                         break
 
                 if matched_ids or still_missing:

--- a/mediamultitool/mmt/updater/get_album_id.py
+++ b/mediamultitool/mmt/updater/get_album_id.py
@@ -95,7 +95,7 @@ def get_fuzzy_deezer_album_id(album_name: str, artist_name: str):
         for album in data["data"]:
 
             albums.append({
-                "id": album['id'],
+                "album_id": album['id'],
                 "title": album['title'],
                 "explcit_lyrics": album['explicit_lyrics'],
                 "record_type": album['record_type'],

--- a/mediamultitool/mmt/updater/get_album_id.py
+++ b/mediamultitool/mmt/updater/get_album_id.py
@@ -1,0 +1,131 @@
+import requests
+import logging
+from ratelimit import limits, sleep_and_retry
+
+DEEZER_API_ROOT = "https://api.deezer.com/"
+DEEZER_CALLS = 50
+DEEZER_PERIOD = 5.01
+
+session = requests.session()
+logger = logging.getLogger(__name__)
+
+HEADER = {
+    'user-agent': 'mediamultitool (by naomisilver@gmail.com)'
+}
+
+@sleep_and_retry
+@limits(calls=DEEZER_CALLS, period=DEEZER_PERIOD) # deezer is limited to 50 requests every 5 seconds, i don't expect to reach that though
+def deezer_get(path, payload):
+    """ rate limited get for deezer """
+    
+    url = f"{DEEZER_API_ROOT}{path}"
+    r = session.get(url, headers=HEADER, params=payload)
+
+    if r.status_code != 200:
+        logger.warning("Deezer request failed: %s %s -> %s; body=%r", path, payload, r.status_code, r.text[:100])
+
+        r.raise_for_status()
+
+    return r
+
+def get_deezer_artist_id(artist_name: str, i: int):
+    """ fuzzy search for artist id (no confidence scoring here so likely same issues I was going to if
+    i used last.fm, I think I will use some album matching, if selected artist's albums match any of those
+    in missing, then it's the right match, otherwise call again to fetch the correct one) 
+    """
+    
+    payload = {
+        'q': artist_name,
+        'limit': 5,
+        'output': 'json'
+    }
+
+    r = deezer_get("/search/artist", payload)
+    data = r.json()
+
+    try:
+        artist_id = data["data"][i]["id"]
+        return artist_id
+    except KeyError:
+        logger.error("Found no artists of name: %s", artist_name)
+    except IndexError:
+        logger.error("Found no viable match for %s", artist_name)
+    
+    return None
+
+def get_deezer_album_id(artist_id: int, index: int) -> dict[str, str]:
+    """ once we got the artist id we can grab the albums of that artist """
+    
+    payload = {
+        'limit': 1000, # deezer doesn't seem to have a listed limit to what they can return but does have a "query quota" but it isn't listed anywhere
+        'index': index, # they do limit to 50 queries every 5 seconds which i rate limit for but yeah, idk 
+        'output': 'json'
+    }
+
+    albums = {}
+
+    r = deezer_get(f"/artist/{artist_id}/albums", payload)
+    data = r.json()
+
+    for album in data["data"]:
+
+        albums[album["title"].lower()] = {
+            "album_id":  album["id"],
+            "explicit_lyrics": album["explicit_lyrics"],
+            "release_date": album["release_date"],
+            "record_type": album['record_type']
+        }
+
+    return albums
+
+def get_fuzzy_deezer_album_id(album_name: str, artist_name: str):
+    """ fuzzy query for album id using album and artist name if it isn't found when querying artist albums """
+
+    payload = {
+        'q': f'{album_name} {artist_name}',
+        'limit': 100,
+        'output': 'json'
+    }
+
+    albums = []
+
+    r = deezer_get(f"/search/album", payload)
+    data = r.json()
+    try:
+        for album in data["data"]:
+
+            albums.append({
+                "id": album['id'],
+                "title": album['title'],
+                "explcit_lyrics": album['explicit_lyrics'],
+                "record_type": album['record_type'],
+                "artist_id": album['artist']['id'],
+                "artist_name": album['artist']['name']
+            })
+    except KeyError:
+        logger.error("No results for %s: %s", artist_name, album_name)
+
+    return albums
+
+def get_album_name_from_id(id: int) -> str:
+    """ exists entirely to check which albums get found for debugging """
+
+    payload = {
+        'limit': 1,
+        'output': 'json'
+    }
+
+    r = deezer_get(f"/album/{id}", payload)
+    data = r.json()
+
+    try:
+        return (data["title"], data["record_type"])
+    except KeyError:
+        return None
+
+"""
+https://api.deezer.com/search/artist/?q=eminem
+https://api.deezer.com/artist/13/albums?limit=500&index=0
+
+there doesn't seem to be a limit to how much I can get back in a single query which is nice
+"""

--- a/mediamultitool/mmt/updater/load_album.py
+++ b/mediamultitool/mmt/updater/load_album.py
@@ -2,6 +2,7 @@ from ..core.models import LocalArtist, CachedArtist, UpdaterConfig
 from ..core.richui import RichUI 
 
 from .get_albums import fetch_artist_albums, fetch_artist_mbid, fetch_many_artist_mbid
+from .download_albums import get_source
 
 from ..core.normalise import normalise
 from ..core.db import Database
@@ -241,6 +242,8 @@ def process_local_artists(upd_cfg: UpdaterConfig, local_artist_data: LocalArtist
     for local_artist in local_artist_data:
         db_artist = db.retrieve_albums(local_artist.artist_name.lower())
 
+        missing_albums[local_artist.artist_name] = {} # accidently recreating the dictionary item every iteration so would end up 
+        # only with the 
         for album_type, ignore in upd_cfg.ignore.items():
             if ignore:
                 continue
@@ -253,7 +256,7 @@ def process_local_artists(upd_cfg: UpdaterConfig, local_artist_data: LocalArtist
             if not missing:
                 continue
 
-            missing_albums[local_artist.artist_name] = {} # only used in writing to a json file, kind of a stopgap until downloading is implemented
+            # only used in writing to a json file, kind of a stopgap until downloading is implemented
             missing_albums[local_artist.artist_name][f"{album_type}s"] = missing # then -d/--download would output the small table and write the json file
             # downloader.py would then take over, using the most recent json file as the stock to download from
 
@@ -269,7 +272,13 @@ def process_local_artists(upd_cfg: UpdaterConfig, local_artist_data: LocalArtist
 
     ui.stop()
 
-    if not upd_cfg.output_to_console:
+    missing_albums = {k: v for k, v in missing_albums.items() if v} # efficient "empty" dict items https://stackoverflow.com/questions/12118695/efficient-way-to-remove-keys-with-empty-strings-from-a-dict
+    # moving the dict key declaration out of the loop, it now generates the key even if there is no missing albums of any type 
+
+    if upd_cfg.download:
+        get_source(upd_cfg, missing_albums)
+
+    elif not upd_cfg.output_to_console:
         write_output_to_json(upd_cfg, missing_albums)
 
 def write_output_to_json(upd_cfg: UpdaterConfig, missing_albums: dict[str: list[str]]):

--- a/mediamultitool/mmt/updater/load_album.py
+++ b/mediamultitool/mmt/updater/load_album.py
@@ -146,11 +146,11 @@ def compare_albums(upd_cfg: UpdaterConfig, db_items: list, local_artist: LocalAr
 
         return missing
 
-def update_cache(local_artist_data: LocalArtist, db: Database): # unsure whether I should include this here or move to a seperate file, will sleep on it
+def update_cache(local_artist_data: LocalArtist, db: Database, ui: RichUI): # unsure whether I should include this here or move to a seperate file, will sleep on it
     """ scans local collection, and updates local cache, based on existance/last_checked, from musicbrainz """
     
-    ui = RichUI()
-    ui.start()
+    #ui = RichUI()
+    #ui.start()
 
     index = 1
 
@@ -184,7 +184,7 @@ def update_cache(local_artist_data: LocalArtist, db: Database): # unsure whether
 
         db.add(updated_a)
 
-    ui.stop()
+    #ui.stop()
 
 def delete_local_missing(upd_cfg: UpdaterConfig, db: Database):
     """ removes artists no longer present in local collection and removes them from local cache """
@@ -230,7 +230,7 @@ def process_local_artists(upd_cfg: UpdaterConfig, local_artist_data: LocalArtist
         logger.info("You have %s outdated artists, you may want to run 'mmt updater --update-cache'", len(stale_artists))
     
     if upd_cfg.update_cache or add_db_missing(upd_cfg, db): # this can be done better when I move each module to a class, this can be called/run the require logic from main
-        update_cache(local_artist_data, db)
+        update_cache(local_artist_data, db, ui)
     elif os.path.isfile(upd_cfg.db_path):
         pass
     else:

--- a/mediamultitool/mmt/updater/streamrip_client.py
+++ b/mediamultitool/mmt/updater/streamrip_client.py
@@ -1,0 +1,51 @@
+from ..core.models import UpdaterConfig
+from ..user_paths import DOWNLOADS_DB_PATH, FAILED_DOWNLOADS_DB_PATH, DEFAULT_DOWNLOAD_DIR
+
+import asyncio
+
+from streamrip.client import DeezerClient
+from streamrip.config import Config
+from streamrip.media import PendingAlbum
+from streamrip.db import Dummy
+from streamrip import db
+
+class StreamripClient(): # a look into the pattern this entire package will follow in the future
+
+    def __init__(self, upd_cfg: UpdaterConfig):
+    
+        self.config = Config.defaults()
+
+        self.downloads_db = db.Downloads(str(DOWNLOADS_DB_PATH))
+        self.failed_db = db.Failed(str(FAILED_DOWNLOADS_DB_PATH))
+
+        #self.db = db.Database(self.downloads_db, self.failed_db) # won't redownload albums that have already been downloaded, diverged from the streamrip docs for this
+        self.db = db.Database(downloads=Dummy(), failed=Dummy()) # and followed the same pattern they used in rip/main.py to use the same db they use. I *could* combine this
+        # with the db created when streamrip is installed as a global package so that I share the same downloads, would be as easy as chaning the global file paths
+
+        self.config.session.downloads.folder = str(DEFAULT_DOWNLOAD_DIR)
+        
+        if upd_cfg.download_source.lower() == "deezer":
+            self.config.session.deezer.arl = upd_cfg.deezer_arl_token
+            self.config.session.deezer.quality = 0
+
+            self.c = DeezerClient(self.config)
+
+    async def init_client(self):
+
+        await self.c.login()
+
+    async def deezer_rip(self, id: int):
+
+        p = PendingAlbum(id, self.c, self.config, self.db)
+        resolved_album = await p.resolve()
+
+        await resolved_album.rip()
+
+    async def close(self):
+        if hasattr(self.c, "session"):
+            await self.c.session.close()
+
+"""
+    - streamrip scripting docs: https://github.com/nathom/streamrip/wiki/Scripting-with-Streamrip-v2
+    - db usage:                 https://github.com/nathom/streamrip/blob/dev/streamrip/rip/main.py
+"""

--- a/mediamultitool/mmt/user_paths.py
+++ b/mediamultitool/mmt/user_paths.py
@@ -8,6 +8,10 @@ CONFIG_PATH = APP_DIR / 'config.toml'
 TEMPLATE_CONFIG_PATH = Path(__file__).parent.with_name("config.toml")
 
 DB_PATH = APP_DIR / 'updater.db'
+DL_DB_DIR = APP_DIR / 'downloads'
+
+DOWNLOADS_DB_PATH = DL_DB_DIR / 'downloads.db'
+FAILED_DOWNLOADS_DB_PATH = DL_DB_DIR / 'failed_downloads.db'
 
 LOG_DIR = APP_DIR / "logs"
 LOG_PATH = APP_DIR / "logs" / "mmt.log"
@@ -17,9 +21,13 @@ REPO_LINK = "https://github.com/naomisilver/mediamultitool"
 
 DEFAULT_OUTPUT_DIR = Path(f"{user_documents_dir()}/{APP_NAME}")
 
+DEFAULT_DOWNLOAD_DIR = DEFAULT_OUTPUT_DIR / 'downloads'
+
 def ensure_paths():
     APP_DIR.mkdir(parents=True, exist_ok=True)
     LOG_DIR.mkdir(parents=True, exist_ok=True)
+    DL_DB_DIR.mkdir(parents=True, exist_ok=True)
+    DEFAULT_DOWNLOAD_DIR.mkdir(parents=True, exist_ok=True)
 
 def ensure_default_output_path():
     DEFAULT_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ dependencies = [
     "selenium",
     "requests",
     "ratelimit",
-    "rich"
+    "rich",
+    "streamrip"
     ]
 description = "A multi-function cli tool to manage self hosted media"
 authors = [{name = "Naomi Silver", email = "naomisilver2002@gmail.com"}]


### PR DESCRIPTION
## Deezer downloading:
- Added `download_albums.py` which orchestrates retrieval of deezer album IDs.
  - Receives a `dict` of missing albums, the key is the artist, the data is then keys of the missing album types
  - Iterates through the dictionary and queries Deezer using `Requests` using the functions following.
  - Creates the `StreamripClient`, logs in using the provided ARL token and iterates and passes the album IDs of missing albums
- Added `get_album_id.py` which resolves given missing albums to their deezer album ID.
  - Added `get_deezer_artist_id` which returns the top ID result of the passed artist string
  - Added `get_deezer_album_id` which returns all albums of the given artist ID
  - Added `get_fuzzy_deezer_album_id` which returns a single album of the given artist name and album name, used as a fallback in the event the previous function does not provide the desired album
  - Added `get_album_name_from_id` which returns a single album name, unused at the moment but used for debugging
- Added `streamrip_client.py` for managing deezer auth and downloading retrieved deezer album IDs.
  - Polymorphic in design for future download sources (e.g., Qobuz, Tidal...) and `streamrip` uses `aiohttp` which requires async and await functions which is easiest implemented externally from the control script
  - This also follows the design pattern of (hopefully) a future major rewrite.

## Beyond core logic:
- Added `RichUI` live table for outputting the found album ids, titles and artists
- Added `~` and `!` to `normalise` in `normalise.py` 
- Fixed bug preventing updating of cache with `RichUI` where two UI instances were created
- Added `streamrip` DB paths to `user_paths.py`
- Added Deezer ARL token and download source fields to `config.toml`/`config.py`

---

## Additional notes: 
- This is not the final state of automatic missing album downloads as Qobuz integration was desired too. However, querying the Qobuz API and downloading from Qobuz requires an active Qobuz subscription. Which I do not have right now. This issue will stay open until that integration is added but this is pretty large leap in functionality and should not sit idle on an issue branch until that integration can be added. (Bad practice I know, a merge and issue shouldn't be closed/merged until the issue is actually completed but hey, to my dismay I'm not a career software dev (yet))